### PR TITLE
Use alias_method

### DIFF
--- a/lib/capitate/cap_ext/connections.rb
+++ b/lib/capitate/cap_ext/connections.rb
@@ -99,7 +99,8 @@ class Capistrano::SSH
       connect_without_logging(server, options, &block)      
     end
   
-    alias_method_chain :connect, :logging
-  
+    alias_method :connect_without_logging, :connect
+    alias_method :connect, :connect_with_logging  
+    
   end
 end


### PR DESCRIPTION
alias_method_chain was a Rails extension, and is deprecated since 2 years, and removed in Rails 3.
